### PR TITLE
Update requests version to 2.32.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 beautifulsoup4==4.7.1
-requests==2.21.0
+requests==2.32.5
 six==1.12.0


### PR DESCRIPTION
Dependency conflict because the version of urllib3 latest (2.5.0) is incompatible with the version of requests  (2.21.0), which requires urllib3 to be <1.25. So we Upgrade requests to a version compatible with urllib3 2.5.0